### PR TITLE
Add metabase setup automation helper functions

### DIFF
--- a/repl_sessions/create_db_conn.clj
+++ b/repl_sessions/create_db_conn.clj
@@ -1,0 +1,36 @@
+(ns create-db-conn 
+  (:require [lambdaisland.embedkit :as e]
+            [lambdaisland.embedkit.setup :as setup]))
+
+(def conn (e/connect {:user "admin@example.com"
+                      :password "secret1"
+                      ;; http://localhost:3000/admin/settings/embedding_in_other_applications
+                      :secret-key "6fa6b6600d27ff276d3d0e961b661fb3b082f8b60781e07d11b8325a6e1025c5"}))
+
+conn
+;; create the database
+(comment
+;; Example for Presto 
+;; Presto driver is going to be deprecated in new version of Metabase.
+  (def db-conn-name "presto-db")
+  (def engine "presto")
+  (def details {:host "localhost"
+                :port 4383
+                :catalog "analytics"
+                :user "."
+                :password ""
+                :ssl false
+                :tunnel-enabled false}))
+(comment
+;; Example for Postgres 
+  (def db-conn-name "kkk")
+  (def engine "postgres")
+  (def details {:host "localhost"
+                :port 5432 
+                :dbname "example_tenant" 
+                :user (System/getenv "POSTGRESQL__USER") 
+                :password (System/getenv "POSTGRESQL__PASSWORD")
+                :ssl false
+                :tunnel-enabled false}))
+
+(setup/create-db! conn db-conn-name engine details)

--- a/repl_sessions/init.clj
+++ b/repl_sessions/init.clj
@@ -13,30 +13,3 @@
                     :secret-key (setup/get-embedding-secret-key (e/connect config))))
 
 (def conn (e/connect config*))
-
-
-;; create the database
-
-
-(def engine "presto")
-(def details {:host "localhost"
-              :port 4383
-              :catalog "analytics"
-              :user "."
-              :password ""
-              :ssl false
-              :tunnel-enabled false})
-(setup/create-db! conn "presto-db" engine details)
-
-;; init finished here
-;; demo
-
-(def db (e/find-database conn "presto-db"))
-
-(:id db)
-
-(def card (e/native-card {:name "my card"
-                          :database (:id db)
-                          :sql "SELECT * FROM EXAMPLE_TENANT__BRANDATWORKS_13082021.journal_entry_line"}))
-
-(r/browse! (e/find-or-create! conn card))

--- a/repl_sessions/init.clj
+++ b/repl_sessions/init.clj
@@ -1,26 +1,37 @@
 (ns init
   (:require [lambdaisland.embedkit :as e]
             [lambdaisland.embedkit.repl :as r]
-            [lambdaisland.automation :as automation]))
+            [lambdaisland.embedkit.setup :as setup]))
 
 (def config {:user "admin@example.com"
              :password "secret1"})
 
 ;; create admin user and enable embedded
-(automation/init-metabase! config)
+(setup/init-metabase! config)
 ;; get the embedding secret key
 (def config* (assoc config
-                    :secret-key (automation/get-embedding-secret-key (e/connect config))))
+                    :secret-key (setup/get-embedding-secret-key (e/connect config))))
 
 (def conn (e/connect config*))
 
+
 ;; create the database
-(automation/create-presto-db! conn "datomic")
+
+
+(def engine "presto")
+(def details {:host "localhost"
+              :port 4383
+              :catalog "analytics"
+              :user "."
+              :password ""
+              :ssl false
+              :tunnel-enabled false})
+(setup/create-db! conn "presto-db" engine details)
 
 ;; init finished here
 ;; demo
 
-(def db (e/find-database conn "datomic"))
+(def db (e/find-database conn "presto-db"))
 
 (:id db)
 

--- a/repl_sessions/init.clj
+++ b/repl_sessions/init.clj
@@ -1,0 +1,31 @@
+(ns init
+  (:require [lambdaisland.embedkit :as e]
+            [lambdaisland.embedkit.repl :as r]
+            [lambdaisland.automation :as automation]))
+
+(def config {:user "admin@example.com"
+             :password "secret1"})
+
+;; create admin user and enable embedded
+(automation/init-metabase! config)
+;; get the embedding secret key
+(def config* (assoc config
+                    :secret-key (automation/get-embedding-secret-key (e/connect config))))
+
+(def conn (e/connect config*))
+
+;; create the database
+(automation/create-presto-db! conn "datomic")
+
+;; init finished here
+;; demo
+
+(def db (e/find-database conn "datomic"))
+
+(:id db)
+
+(def card (e/native-card {:name "my card"
+                          :database (:id db)
+                          :sql "SELECT * FROM EXAMPLE_TENANT__BRANDATWORKS_13082021.journal_entry_line"}))
+
+(r/browse! (e/find-or-create! conn card))

--- a/src/lambdaisland/automation.clj
+++ b/src/lambdaisland/automation.clj
@@ -1,0 +1,103 @@
+(ns lambdaisland.automation
+  "The automation helpers to automate the init setup of metabase"
+  (:require [lambdaisland.embedkit :as embedkit]
+            [clojure.data.json :as json]
+            [hato.client :as http]))
+
+(defn metabase-endpoint
+  "Create the base url of metabase"
+  [https? host port]
+  (str "http" (when https? "s") "://" host (when port (str ":" port))))
+
+(defn get-metabase-setup-token!
+  "Get the metabase setup token by using /api/session/properties GET API"
+  [base-url]
+  (let [session-url (str base-url "/api/session/properties")
+        {:keys [status body]} (http/request {:method :get
+                                             :url session-url
+                                             :content-type :json})]
+    (when (= 200 status)
+      (:setup-token (json/read-str body
+                                   :key-fn keyword)))))
+
+(defn create-admin-user!
+  "Create the first/admin user of the metabase, and get the session-key"
+  [base-url setup-token user password]
+  (let [setup-url (str base-url "/api/setup")
+        data {:token setup-token
+              :user {:email user :password password
+                     :first_name "Eleven" :last_name "Run"}
+              :prefs {:site_name "Metabase BI"}}
+        {:keys [status body]} (http/request {:method :post
+                                             :url setup-url
+                                             :content-type :json
+                                             :form-params data})]
+    (when (= 200 status)
+      (:id (json/read-str body
+                          :key-fn keyword)))))
+
+(defn enable-embedding!
+  "change the metabase setting using /api/setting PUT API to enable embedding"
+  [base-url session-key]
+  (let [setting-url (str base-url "/api/setting/enable-embedding")
+        data {:key "enable-embedding"
+              :value true}
+        {:keys [status body]} (http/request {:headers {"x-metabase-session" session-key}
+                                             :method :put
+                                             :url setting-url
+                                             :content-type :json
+                                             :form-params data})]
+    (when (= 200 status)
+      (json/read-str body
+                     :key-fn keyword))))
+
+(defn get-metabase-setting-by-key!
+  "get metabase setting using /api/setting GET API"
+  [e-conn key]
+  (let [resp (embedkit/mb-get e-conn "/api/setting/")
+        kv-pairs (filterv #(= (:key %) key) (:body resp))]
+    (:value (first kv-pairs))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; init API
+
+
+(defn init-metabase!
+  "Doing the following things:
+   
+   1. create the first user
+   2. enable embedding"
+  [{:keys [user password
+           ;; optional 
+           https? host port]
+    :or {https? false
+         host "localhost"
+         port 3000}}]
+  (let [base-url (metabase-endpoint https? host port)
+        setup-token (get-metabase-setup-token! base-url)
+        session-key (create-admin-user! base-url setup-token user password)]
+    (enable-embedding! base-url session-key)))
+
+(defn get-embedding-secret-key
+  "retrive the embedding-secret-key"
+  [e-conn]
+  (get-metabase-setting-by-key! e-conn "embedding-secret-key"))
+
+(defn create-presto-db!
+  "Create the presto-db in metabase if it does not exist"
+  [e-conn presto-db-name]
+  (when (nil? (embedkit/find-database e-conn presto-db-name))
+    (do
+      (embedkit/mb-post
+       e-conn
+       "/api/database"
+       {:form-params {:name presto-db-name
+                      :engine "presto"
+                      :details
+                      {:host "localhost"
+                       :port 4383
+                       :catalog "analytics"
+                       :user "."
+                       :password ""
+                       :ssl false
+                       :tunnel-enabled false}}}))))

--- a/src/lambdaisland/automation.clj
+++ b/src/lambdaisland/automation.clj
@@ -61,14 +61,13 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; init API
 
-
 (defn init-metabase!
   "Doing the following things:
-   
+
    1. create the first user
    2. enable embedding"
   [{:keys [user password
-           ;; optional 
+           ;; optional
            https? host port]
     :or {https? false
          host "localhost"

--- a/src/lambdaisland/automation.clj
+++ b/src/lambdaisland/automation.clj
@@ -26,7 +26,7 @@
   (let [setup-url (str base-url "/api/setup")
         data {:token setup-token
               :user {:email user :password password
-                     :first_name "Eleven" :last_name "Run"}
+                     :first_name "lambdaisland.com" :last_name "gaiwan.co"}
               :prefs {:site_name "Metabase BI"}}
         {:keys [status body]} (http/request {:method :post
                                              :url setup-url

--- a/src/lambdaisland/embedkit.clj
+++ b/src/lambdaisland/embedkit.clj
@@ -58,9 +58,9 @@
 
       (and (not (hato-mw/unexceptional-status? status)) (= coerce :exceptional))
       (with-open [r (io/reader body :encoding charset)]
-        (assoc resp :body  (json/read r
-                                      :key-fn keyword
-                                      :eof-error? false)))
+        (assoc resp :body (json/read r
+                                     :key-fn keyword
+                                     :eof-error? false)))
 
       :else (assoc resp :body (slurp body :encoding charset)))))
 

--- a/src/lambdaisland/embedkit/setup.clj
+++ b/src/lambdaisland/embedkit/setup.clj
@@ -1,4 +1,4 @@
-(ns lambdaisland.automation
+(ns lambdaisland.embedkit.setup
   "The automation helpers to automate the init setup of metabase"
   (:require [lambdaisland.embedkit :as embedkit]
             [clojure.data.json :as json]
@@ -80,23 +80,18 @@
 (defn get-embedding-secret-key
   "retrive the embedding-secret-key"
   [e-conn]
+  {:pre [(record? e-conn)]}
   (get-metabase-setting-by-key! e-conn "embedding-secret-key"))
 
-(defn create-presto-db!
-  "Create the presto-db in metabase if it does not exist"
-  [e-conn presto-db-name]
-  (when (nil? (embedkit/find-database e-conn presto-db-name))
+(defn create-db!
+  "Create the database in metabase if it does not exist"
+  [e-conn db-name engine details]
+  {:pre [(record? e-conn) (string? db-name) (string? engine) (map? details)]}
+  (when (nil? (embedkit/find-database e-conn db-name))
     (do
       (embedkit/mb-post
        e-conn
        "/api/database"
-       {:form-params {:name presto-db-name
-                      :engine "presto"
-                      :details
-                      {:host "localhost"
-                       :port 4383
-                       :catalog "analytics"
-                       :user "."
-                       :password ""
-                       :ssl false
-                       :tunnel-enabled false}}}))))
+       {:form-params {:name db-name
+                      :engine engine
+                      :details details}}))))

--- a/src/lambdaisland/embedkit/setup.clj
+++ b/src/lambdaisland/embedkit/setup.clj
@@ -85,13 +85,13 @@
 
 (defn create-db!
   "Create the database in metabase if it does not exist"
-  [e-conn db-name engine details]
-  {:pre [(record? e-conn) (string? db-name) (string? engine) (map? details)]}
-  (when (nil? (embedkit/find-database e-conn db-name))
-    (do
-      (embedkit/mb-post
-       e-conn
-       "/api/database"
-       {:form-params {:name db-name
-                      :engine engine
-                      :details details}}))))
+  [e-conn db-conn-name engine details]
+  {:pre [(record? e-conn) (string? db-conn-name) (string? engine) (map? details)]}
+  (if (nil? (embedkit/find-database e-conn db-conn-name))
+    (embedkit/mb-post
+     e-conn
+     "/api/database"
+     {:form-params {:name db-conn-name
+                    :engine engine
+                    :details details}})
+    (prn "duplicated db-conn-name " db-conn-name "already exists.")))


### PR DESCRIPTION
The PR adds some setup automation helpers for metabase:

- [x] create the first admin user with given `username/password` and enable embedding 
- [x] get the embedding-secret-key
- [x] create the database with given `database name`
- [x] there are some pre conditions on helper functions  