### PR TITLE
Extended design of field-id related lookup functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,19 @@ See the example file from `repl_sessions/create_db_conn.clj`
 (e/trigger-db-fn! conn "example_tenant" :rescan_values)
 ```
 
+### ID lookup utilities 
+For human, it is natural to remember the name of an entity, be it a database, 
+database schema, or a table. On the other hand, inside metabase, these entities are 
+all represented by numeric IDs.
+That is why we also provide a series of ID lookup utilities:
+```
+(find-database ...)  ;; get the database entity information which include db-id through database-name
+(table-id ...)       ;; find out field-id by database-name, schema-name, table-name
+(field-id ...)       ;; find out field-id by database-name, schema-name, table-name, field-name
+(user-id ...)        ;; find out user-id by email
+(group-id ...)       ;; find out group-id by group-name
+```
+
 <!-- contributing -->
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -275,6 +275,13 @@ See the example file from `repl_sessions/create_db_conn.clj`
 (setup/create-db! conn db-conn-name engine details)
 ```
 
+#### Trigger the sync of a db schema and field values
+
+```
+(e/trigger-db-fn! conn "example_tenant" :sync_schema)
+(e/trigger-db-fn! conn "example_tenant" :rescan_values)
+```
+
 <!-- contributing -->
 ## Contributing
 

--- a/repl_sessions/lookup_id.clj
+++ b/repl_sessions/lookup_id.clj
@@ -22,3 +22,6 @@ conn
 
 (e/fetch-all-groups conn)
 (e/group-id conn "Administrators")
+
+(e/trigger-db-fn! conn "example_tenant" "sync_schema")
+(e/trigger-db-fn! conn "example_tenant" "rescan_values")

--- a/repl_sessions/lookup_id.clj
+++ b/repl_sessions/lookup_id.clj
@@ -19,3 +19,6 @@ conn
 
 (e/fetch-all-users conn)
 (e/user-id conn "aaa@example.com")
+
+(e/fetch-all-groups conn)
+(e/group-id conn "Administrators")

--- a/repl_sessions/lookup_id.clj
+++ b/repl_sessions/lookup_id.clj
@@ -10,8 +10,6 @@
 conn
 
 (def db (e/find-database conn "example_tenant"))
-
-
 ;;
 (e/fetch-database-fields conn (:id db))
 (e/table-id conn "example_tenant" "enzo" "Denormalised General Ledger entries - Draft and Posted")
@@ -23,5 +21,5 @@ conn
 (e/fetch-all-groups conn)
 (e/group-id conn "Administrators")
 
-(e/trigger-db-fn! conn "example_tenant" "sync_schema")
-(e/trigger-db-fn! conn "example_tenant" "rescan_values")
+(e/trigger-db-fn! conn "example_tenant" :sync_schema)
+(e/trigger-db-fn! conn "example_tenant" :rescan_values)

--- a/repl_sessions/lookup_id.clj
+++ b/repl_sessions/lookup_id.clj
@@ -1,0 +1,18 @@
+(ns lookup-id 
+  (:require [clojure.pprint :as pprint]
+            [clojure.string :as str]
+            [lambdaisland.embedkit :as e]))
+
+(def conn (e/connect {:user "admin@example.com"
+                      :password "secret1"
+                      ;; http://localhost:3000/admin/settings/embedding_in_other_applications
+                      :secret-key "6fa6b6600d27ff276d3d0e961b661fb3b082f8b60781e07d11b8325a6e1025c5"}))
+conn
+
+(def db (e/find-database conn "example_tenant"))
+
+
+;;
+(e/fetch-database-fields conn (:id db))
+(e/table-id conn "example_tenant" "enzo" "Denormalised General Ledger entries - Draft and Posted")
+(e/field-id conn "example_tenant" "enzo" "Denormalised General Ledger entries - Draft and Posted" "document_date")

--- a/repl_sessions/lookup_id.clj
+++ b/repl_sessions/lookup_id.clj
@@ -16,3 +16,6 @@ conn
 (e/fetch-database-fields conn (:id db))
 (e/table-id conn "example_tenant" "enzo" "Denormalised General Ledger entries - Draft and Posted")
 (e/field-id conn "example_tenant" "enzo" "Denormalised General Ledger entries - Draft and Posted" "document_date")
+
+(e/fetch-all-users conn)
+(e/user-id conn "aaa@example.com")

--- a/src/lambdaisland/embedkit.clj
+++ b/src/lambdaisland/embedkit.clj
@@ -338,6 +338,16 @@
                          cache groups)))
         (get-in @(:cache conn) path)))))
 
+(defn trigger-db-fn!
+  "When success, return ... "
+  [conn db-name db-fn-link]
+  {:pre [(#{"sync_schema" "rescan_values"} db-fn-link )]}
+  (let [db-id (:id (find-database conn db-name))
+        resp (-> conn
+                 (mb-post [:database db-id (keyword db-fn-link)])
+                 (get-in [:body]))]
+    resp))
+
 (def embedkit-keys
   "Keys that we add interally to entity maps. Generally we deal with data exactly
   as the Metabase API expects it and returns, but we add these namespaced keys

--- a/src/lambdaisland/embedkit.clj
+++ b/src/lambdaisland/embedkit.clj
@@ -341,7 +341,8 @@
 (defn trigger-db-fn!
   "When success, return ... "
   [conn db-name db-fn-link]
-  {:pre [(#{"sync_schema" "rescan_values"} db-fn-link )]}
+  {:pre [(or (#{"sync_schema" "rescan_values"} db-fn-link)
+             (#{:sync_schema :rescan_values} db-fn-link))]}
   (let [db-id (:id (find-database conn db-name))
         resp (-> conn
                  (mb-post [:database db-id (keyword db-fn-link)])

--- a/src/lambdaisland/embedkit.clj
+++ b/src/lambdaisland/embedkit.clj
@@ -291,7 +291,7 @@
   "Get users. Always does a request."
   [client]
   (let [user-list (-> client
-                      (mb-get [:user] 
+                      (mb-get [:user]
                               {:query-params {:include_deactivated "true"}})
                       (get-in [:body]))]
     user-list))
@@ -301,7 +301,6 @@
   [conn email]
   (let [path [:user-email email
               :id]]
-    (prn "user-id " path)
     (if-let [id (get-in @(:cache conn) path)]
       id
       (let [users (fetch-all-users conn)]
@@ -312,6 +311,31 @@
                                      [:user-email email
                                       :id] id))
                          cache users)))
+        (get-in @(:cache conn) path)))))
+
+(defn fetch-all-groups
+  "Get groups. Always does a request."
+  [client]
+  (let [group (-> client
+                  (mb-get [:permissions :group])
+                  (get-in [:body]))]
+    group))
+
+(defn group-id
+  "Find the numeric id of a given group name. Leverages the cache."
+  [conn name]
+  (let [path [:group-name name
+              :id]]
+    (if-let [id (get-in @(:cache conn) path)]
+      id
+      (let [groups (fetch-all-groups conn)]
+        (swap! (:cache conn)
+               (fn [cache]
+                 (reduce (fn [c {:keys [name id]}]
+                           (assoc-in c
+                                     [:group-name name
+                                      :id] id))
+                         cache groups)))
         (get-in @(:cache conn) path)))))
 
 (def embedkit-keys


### PR DESCRIPTION
# ID lookup 

- [x] Add `table-id` **id lookup** function. Deliberately to extend the original design of `field-id` **id lookup** function. 
- [x] Add `user-id` **id lookup** function
- [x] Add `group-id` **id lookup** function
- [x] Add `trigger-db-fn!`