### PR TITLE
comform to  metabase API version 0.44.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ## Changed
 
+- [breaking] Support only metabase version >= `0.40.0`
+- Support the pagination feature of `/api/user` [Ref](https://github.com/metabase/metabase/wiki/What%27s-new-in-0.40.0-for-Metabase-REST-API-clients)
+
 # 0.0.24 (2022-11-13 / 23678d6)
 
 ## Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 ## Added
 
+- Add fetch-users API
+
 ## Fixed
 
 ## Changed
 
-- [breaking] Change `embedkit/fetch-all-users` to `embedkit/fetch-users`
 - [breaking] Support only metabase version >= `0.40.0`
 - Support the pagination feature of `/api/user` [Ref](https://github.com/metabase/metabase/wiki/What%27s-new-in-0.40.0-for-Metabase-REST-API-clients)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ## Changed
 
+- [breaking] Change `embedkit/fetch-all-users` to `embedkit/fetch-users`
 - [breaking] Support only metabase version >= `0.40.0`
 - Support the pagination feature of `/api/user` [Ref](https://github.com/metabase/metabase/wiki/What%27s-new-in-0.40.0-for-Metabase-REST-API-clients)
 

--- a/README.md
+++ b/README.md
@@ -295,8 +295,13 @@ That is why we also provide a series of ID lookup utilities:
 (group-id ...)       ;; find out group-id by group-name
 ```
 
-### Pagination Issues
-The newest release version of embedkit is developed toward metabase version `0.44.6`.
+### Metabase version & related issues
+
+#### Supported Metabase version
+0.44.0 or later
+
+#### Pagination
+The newest release version of embedkit is developed along with metabase version `0.44.6`.
 According to [here](https://github.com/metabase/metabase/wiki/What%27s-new-in-0.40.0-for-Metabase-REST-API-clients), metabase should have `/api/user` and `/api/database` supporting pagination feature. However, real world testing shows that only `/api/user` has the pagination feature. Also, the `total` in the return result of `/api/user` is actually refering to the total number of users rather than the total number of users with respect to the query.
 
 <!-- contributing -->

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ See the example file from `repl_sessions/create_db_conn.clj`
 (e/trigger-db-fn! conn "example_tenant" :rescan_values)
 ```
 
-### ID lookup utilities 
+#### ID lookup utilities
 For human, it is natural to remember the name of an entity, be it a database, 
 database schema, or a table. On the other hand, inside metabase, these entities are 
 all represented by numeric IDs.
@@ -294,6 +294,10 @@ That is why we also provide a series of ID lookup utilities:
 (user-id ...)        ;; find out user-id by email
 (group-id ...)       ;; find out group-id by group-name
 ```
+
+### Pagination Issues
+The newest release version of embedkit is developed toward metabase version `0.44.6`.
+According to [here](https://github.com/metabase/metabase/wiki/What%27s-new-in-0.40.0-for-Metabase-REST-API-clients), metabase should have `/api/user` and `/api/database` supporting pagination feature. However, real world testing shows that only `/api/user` has the pagination feature. Also, the `total` in the return result of `/api/user` is actually refering to the total number of users rather than the total number of users with respect to the query.
 
 <!-- contributing -->
 ## Contributing

--- a/dev/config.edn
+++ b/dev/config.edn
@@ -1,0 +1,3 @@
+{:user "admin@example.com"
+ :password "aqd4ijj4"
+ :secret-key "6fa6b6600d27ff276d3d0e961b661fb3b082f8b60781e07d11b8325a6e1025c5"}

--- a/repl_sessions/create_db_conn.clj
+++ b/repl_sessions/create_db_conn.clj
@@ -1,11 +1,9 @@
-(ns create-db-conn 
+(ns create-db-conn
   (:require [lambdaisland.embedkit :as e]
             [lambdaisland.embedkit.setup :as setup]))
 
-(def conn (e/connect {:user "admin@example.com"
-                      :password "secret1"
-                      ;; http://localhost:3000/admin/settings/embedding_in_other_applications
-                      :secret-key "6fa6b6600d27ff276d3d0e961b661fb3b082f8b60781e07d11b8325a6e1025c5"}))
+(def conn
+  (e/connect (read-string (slurp "dev/config.edn"))))
 
 conn
 ;; create the database
@@ -26,9 +24,9 @@ conn
   (def db-conn-name "kkk")
   (def engine "postgres")
   (def details {:host "localhost"
-                :port 5432 
-                :dbname "example_tenant" 
-                :user (System/getenv "POSTGRESQL__USER") 
+                :port 5432
+                :dbname "example_tenant"
+                :user (System/getenv "POSTGRESQL__USER")
                 :password (System/getenv "POSTGRESQL__PASSWORD")
                 :ssl false
                 :tunnel-enabled false}))

--- a/repl_sessions/find_db.clj
+++ b/repl_sessions/find_db.clj
@@ -1,0 +1,12 @@
+(ns find-db
+  (:require [lambdaisland.embedkit :as e]))
+
+(def conn (e/connect {:user "admin@example.com"
+                      :password "aqd4ijj4"
+                      :secret-key "6fa6b6600d27ff276d3d0e961b661fb3b082f8b60781e07d11b8325a6e1025c5"}))
+
+(e/find-database conn "example_tenant")
+
+(:id (e/find-database conn "example_tenant"))
+
+(e/mb-get conn [:database])

--- a/repl_sessions/find_db.clj
+++ b/repl_sessions/find_db.clj
@@ -1,9 +1,8 @@
 (ns find-db
   (:require [lambdaisland.embedkit :as e]))
 
-(def conn (e/connect {:user "admin@example.com"
-                      :password "aqd4ijj4"
-                      :secret-key "6fa6b6600d27ff276d3d0e961b661fb3b082f8b60781e07d11b8325a6e1025c5"}))
+(def conn
+  (e/connect (read-string (slurp "dev/config.edn"))))
 
 (e/find-database conn "example_tenant")
 

--- a/repl_sessions/init.clj
+++ b/repl_sessions/init.clj
@@ -4,7 +4,7 @@
             [lambdaisland.embedkit.setup :as setup]))
 
 (def config {:user "admin@example.com"
-             :password "secret1"})
+             :password "aqd4ijj4"})
 
 ;; create admin user and enable embedded
 (setup/init-metabase! config)

--- a/repl_sessions/lookup_id.clj
+++ b/repl_sessions/lookup_id.clj
@@ -1,12 +1,11 @@
-(ns lookup-id 
+(ns lookup-id
   (:require [clojure.pprint :as pprint]
             [clojure.string :as str]
             [lambdaisland.embedkit :as e]))
 
-(def conn (e/connect {:user "admin@example.com"
-                      :password "secret1"
-                      ;; http://localhost:3000/admin/settings/embedding_in_other_applications
-                      :secret-key "6fa6b6600d27ff276d3d0e961b661fb3b082f8b60781e07d11b8325a6e1025c5"}))
+(def conn
+  (e/connect (read-string (slurp "dev/config.edn"))))
+
 conn
 
 (def db (e/find-database conn "example_tenant"))
@@ -16,7 +15,7 @@ conn
 (e/field-id conn "example_tenant" "enzo" "Denormalised General Ledger entries - Draft and Posted" "document_date")
 
 (e/fetch-all-users conn)
-(e/user-id conn "aaa@example.com")
+(e/user-id conn "admin@example.com")
 
 (e/fetch-all-groups conn)
 (e/group-id conn "Administrators")

--- a/repl_sessions/lookup_id.clj
+++ b/repl_sessions/lookup_id.clj
@@ -18,6 +18,7 @@ conn
  @(:cache conn)
  [:databases "example_tenant" :schemas "enzo" :tables  "Denormalised General Ledger entries - Draft and Posted"])
 
+(e/fetch-all-users conn)
 (e/fetch-users conn :all)
 (e/user-id conn "admin@example.com")
 

--- a/repl_sessions/lookup_id.clj
+++ b/repl_sessions/lookup_id.clj
@@ -18,7 +18,7 @@ conn
  @(:cache conn)
  [:databases "example_tenant" :schemas "enzo" :tables  "Denormalised General Ledger entries - Draft and Posted"])
 
-(e/fetch-all-users conn)
+(e/fetch-users conn :all)
 (e/user-id conn "admin@example.com")
 
 (e/fetch-all-groups conn)

--- a/repl_sessions/lookup_id.clj
+++ b/repl_sessions/lookup_id.clj
@@ -14,6 +14,10 @@ conn
 (e/table-id conn "example_tenant" "enzo" "Denormalised General Ledger entries - Draft and Posted")
 (e/field-id conn "example_tenant" "enzo" "Denormalised General Ledger entries - Draft and Posted" "document_date")
 
+(get-in
+ @(:cache conn)
+ [:databases "example_tenant" :schemas "enzo" :tables  "Denormalised General Ledger entries - Draft and Posted"])
+
 (e/fetch-all-users conn)
 (e/user-id conn "admin@example.com")
 

--- a/repl_sessions/pagination.clj
+++ b/repl_sessions/pagination.clj
@@ -1,0 +1,25 @@
+(ns pagination
+  (:require [lambdaisland.embedkit :as e]))
+
+(def conn
+  (e/connect (read-string (slurp "dev/config.edn"))))
+
+(e/fetch-all-users conn)
+
+(e/find-database conn "example_tenant")
+
+(comment
+  (get-in (e/mb-get conn [:database]
+                    {:query-params {:limit 1
+                                    :offset 1}})
+          [:body])
+
+  (get-in (e/mb-get conn [:user]
+                    {:query-params {:limit 1
+                                    :offset 0}})
+          [:body])
+
+  (get-in (e/mb-get conn [:user]
+                    {:query-params {:limit 1
+                                    :offset 1}})
+          [:body]))

--- a/repl_sessions/pagination.clj
+++ b/repl_sessions/pagination.clj
@@ -4,7 +4,8 @@
 (def conn
   (e/connect (read-string (slurp "dev/config.edn"))))
 
-(e/fetch-all-users conn)
+(e/fetch-users conn :all)
+(e/fetch-users conn :active)
 
 (e/find-database conn "example_tenant")
 

--- a/src/lambdaisland/embedkit.clj
+++ b/src/lambdaisland/embedkit.clj
@@ -293,7 +293,7 @@
   (let [user-list (-> client
                       (mb-get [:user]
                               {:query-params {:include_deactivated "true"}})
-                      (get-in [:body]))]
+                      (get-in [:body :data]))]
     user-list))
 
 (defn user-id

--- a/src/lambdaisland/embedkit.clj
+++ b/src/lambdaisland/embedkit.clj
@@ -219,7 +219,7 @@
                  :databases
                  (fnil into {})
                  (doto (map (juxt :name identity)
-                            (:body (mb-get conn [:database])))))
+                            (get-in (mb-get conn [:database]) [:body :data]))))
           (get-in @(:cache conn) path)))))
 
 (defn fetch-database-fields

--- a/src/lambdaisland/embedkit.clj
+++ b/src/lambdaisland/embedkit.clj
@@ -321,6 +321,16 @@
                          cache fields)))
         (get-in @(:cache conn) path)))))
 
+(defn fetch-all-users
+  "Get users. Always does a request."
+  [client]
+  (let [query-opts {:include_deactivated "true"}
+        f (wrap-paginate mb-get default-pagination-size)
+        user-list (-> client
+                      (f [:user]
+                         {:query-params query-opts}))]
+    (vec user-list)))
+
 (defn fetch-users
   "Get users:
 


### PR DESCRIPTION
The metabase API schema changes. One of the change is that: 
- at version 0.39.4, when we hit the database API, the body returns `$the-lists-of-all-databases`. 
- at version 0.44.6, when we hit the database API, the body returns `{:data $the-lists-of-all-databases}`

=> `/api/user` and `/api/database` have this change. 

## Other things
- I also add the suggestions from Arne about id-lookup into this PR. 