### PR TITLE
improve init metabase function

### DIFF
--- a/dev/config.edn
+++ b/dev/config.edn
@@ -1,3 +1,6 @@
 {:user "admin@example.com"
  :password "aqd4ijj4"
- :secret-key "6fa6b6600d27ff276d3d0e961b661fb3b082f8b60781e07d11b8325a6e1025c5"}
+ :secret-key "6fa6b6600d27ff276d3d0e961b661fb3b082f8b60781e07d11b8325a6e1025c5"
+ :first-name "Laurence" 
+ :last-name "Chen" 
+ :site-name "My site"}

--- a/repl_sessions/init.clj
+++ b/repl_sessions/init.clj
@@ -3,11 +3,20 @@
             [lambdaisland.embedkit.repl :as r]
             [lambdaisland.embedkit.setup :as setup]))
 
-(def config 
-  (select-keys (read-string (slurp "dev/config.edn")) 
+(def config
+  (select-keys (read-string (slurp "dev/config.edn"))
                [:user :password]))
+(comment
+  ;; first-name, last-name, site-name are optional parameters
+  (def config
+    (select-keys (read-string (slurp "dev/config.edn"))
+                 [:user :password
+                  :first-name :last-name
+                  :site-name])))
 
 ;; create admin user and enable embedded
+
+
 (setup/init-metabase! config)
 
 ;; setup embedding secret key

--- a/src/lambdaisland/embedkit/setup.clj
+++ b/src/lambdaisland/embedkit/setup.clj
@@ -22,12 +22,13 @@
 
 (defn create-admin-user!
   "Create the first/admin user of the metabase, and get the session-key"
-  [base-url setup-token user password]
+  [{:keys [base-url setup-token email password
+           first-name last-name site-name]}]
   (let [setup-url (str base-url "/api/setup")
         data {:token setup-token
-              :user {:email user :password password
-                     :first_name "lambdaisland.com" :last_name "gaiwan.co"}
-              :prefs {:site_name "Metabase BI"}}
+              :user {:email email :password password
+                     :first_name first-name :last_name last-name}
+              :prefs {:site_name site-name}}
         {:keys [status body]} (http/request {:method :post
                                              :url setup-url
                                              :content-type :json
@@ -74,13 +75,23 @@
    2. enable embedding"
   [{:keys [user password
            ;; optional
+           first-name last-name site-name
            https? host port]
-    :or {https? false
+    :or {first-name "lambdaisland.com"
+         last-name "gaiwan.co"
+         site-name "Metabase BI"
+         https? false
          host "localhost"
          port 3000}}]
   (let [base-url (metabase-endpoint https? host port)
         setup-token (get-metabase-setup-token! base-url)
-        session-key (create-admin-user! base-url setup-token user password)]
+        session-key (create-admin-user! {:base-url base-url
+                                         :setup-token setup-token
+                                         :email user
+                                         :password password
+                                         :first-name first-name
+                                         :last-name last-name
+                                         :site-name site-name})]
     (comment (prn {:base-url base-url
                    :setup-token setup-token
                    :session-key session-key}))


### PR DESCRIPTION
The original `(setup/init-metabase! config)` does not support `first-name, last-name, site-name`.

In this PR, I add support for the three parameters. They are still optional. 
